### PR TITLE
ci: run tests in Travis Ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+tests/compat/*.bin
+tests/compat/*.elf
+tests/compat/*.o
+tests/compat/*.ulp
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,43 @@
+language: c
+dist: trusty
+sudo: false
+addons:
+  apt:
+    packages:
+      - libffi-dev
+      - pkg-config
+
+
+script:
+  - export VER=$(git describe --always --tags)
+  - echo ${VER}
+
+  ###### Install tools ######
+
+  - echo "Building micropython"
+  - git clone --recursive https://github.com/micropython/micropython.git
+  - pushd micropython/ports/unix
+  - git describe --always --tags
+  - make axtls
+  - make
+  - export PATH=$PATH:$PWD
+  - test $(micropython -c 'print("test")') = "test"
+  - popd
+
+  - echo "Building binutils-esp32ulp"
+  - git clone https://github.com/espressif/binutils-esp32ulp.git
+  - pushd binutils-esp32ulp
+  - git describe --always --tags
+  - ./configure --target=esp32ulp-elf --prefix=$PWD/dist --disable-doc --disable-gdb --disable-libdecnumber --disable-readline --disable-sim
+  - echo "MAKEINFO = :" >> Makefile
+  - make
+  - make install-strip
+  - export PATH=$PATH:$PWD/dist/bin
+  - esp32ulp-elf-as --version | grep 'esp32ulp-elf' > /dev/null
+  - popd
+
+  ###### Run tests ######
+
+  - pushd tests
+  - ./00_run_tests.sh
+

--- a/tests/00_run_tests.sh
+++ b/tests/00_run_tests.sh
@@ -1,7 +1,38 @@
+#!/bin/bash
+
 # export PYTHONPATH=.:$PYTHONPATH
+
+set -e
 
 for file in opcodes assemble link ; do
     echo testing $file...
     micropython $file.py
 done
 
+for src_file in $(ls -1 compat/*.S); do
+    src_name="${src_file%.S}"
+    
+    echo "Building $src_file using py-esp32-ulp"
+    ulp_file="${src_name}.ulp"
+    micropython -m esp32_ulp $src_file    # generates $ulp_file
+
+    obj_file="${src_name}.o"
+    elf_file="${src_name}.elf"
+    bin_file="${src_name}.bin"
+
+    echo "Building $src_file using binutils"
+    esp32ulp-elf-as -o $obj_file $src_file
+    esp32ulp-elf-ld -T esp32.ulp.ld -o $elf_file $obj_file
+    esp32ulp-elf-objcopy -O binary $elf_file $bin_file
+
+    if ! diff $ulp_file $bin_file; then
+        echo "Compatibility test failed for $src_file"
+        echo "py-esp32-ulp output:"
+        hexdump $ulp_file
+        echo "binutils output:"
+        hexdump $bin_file
+        exit 1
+    else
+        echo "Build outputs match for $src_file"
+    fi
+done

--- a/tests/compat/alu.S
+++ b/tests/compat/alu.S
@@ -1,0 +1,21 @@
+            .text
+            
+            and r1, r2, r3
+            and r3, r0, 0xffff
+            and r1, r1, 0xa5a5
+
+            or r1, r2, r3
+            or r3, r0, 0xffff
+            or r1, r1, 0xa5a5
+
+            add r1, r1, 32767
+            add r0, r3, -32768
+            add r3, r0, -1
+            add r2, r1, 1
+
+            sub r1, r1, 32767
+            sub r0, r3, -32768
+            sub r3, r0, -1
+            sub r2, r1, 1
+
+

--- a/tests/esp32.ulp.ld
+++ b/tests/esp32.ulp.ld
@@ -1,0 +1,35 @@
+ULP_BIN_MAGIC = 0x00706c75;
+HEADER_SIZE = 12;
+CONFIG_ULP_COPROC_RESERVE_MEM = 4096;
+
+MEMORY
+{
+    ram(RW) : ORIGIN = 0, LENGTH = CONFIG_ULP_COPROC_RESERVE_MEM
+}
+
+SECTIONS
+{
+    .text : AT(HEADER_SIZE)
+    {
+        *(.text)
+    } >ram
+    .data :
+    {
+        . = ALIGN(4);
+        *(.data)
+    } >ram
+    .bss :
+    {
+        . = ALIGN(4);
+        *(.bss)
+    } >ram
+    
+    .header : AT(0)
+    {
+        LONG(ULP_BIN_MAGIC)
+        SHORT(LOADADDR(.text)) 
+        SHORT(SIZEOF(.text))
+        SHORT(SIZEOF(.data))
+        SHORT(SIZEOF(.bss))
+    }
+}


### PR DESCRIPTION
- download and build micropython and binutils-esp32
- run existing test cases using micropython
- build files under tests/compat/*.S using both tools and compare
- one simple test case (tests/compat/alu.S) included

See https://github.com/ThomasWaldmann/py-esp32-ulp/issues/13