### PR TITLE
ci: clean up output, use xxd when dumping binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ tests/compat/*.bin
 tests/compat/*.elf
 tests/compat/*.o
 tests/compat/*.ulp
+tests/compat/*.log
 .DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ script:
 
   ###### Install tools ######
 
+  - echo -e "travis_fold:start:build_micropython"
   - echo "Building micropython"
   - git clone --recursive https://github.com/micropython/micropython.git
   - pushd micropython/ports/unix
@@ -23,7 +24,9 @@ script:
   - export PATH=$PATH:$PWD
   - test $(micropython -c 'print("test")') = "test"
   - popd
+  - echo -e "travis_fold:end:build_micropython"
 
+  - echo -e "travis_fold:start:build_binutils"
   - echo "Building binutils-esp32ulp"
   - git clone https://github.com/espressif/binutils-esp32ulp.git
   - pushd binutils-esp32ulp
@@ -35,9 +38,17 @@ script:
   - export PATH=$PATH:$PWD/dist/bin
   - esp32ulp-elf-as --version | grep 'esp32ulp-elf' > /dev/null
   - popd
+  - echo -e "travis_fold:end:build_binutils"
 
   ###### Run tests ######
 
   - pushd tests
-  - ./00_run_tests.sh
+  
+  - echo -e "travis_fold:start:unit_tests"
+  - ./00_unit_tests.sh
+  - echo -e "travis_fold:end:unit_tests"
+
+  - echo -e "travis_fold:start:compat_tests"
+  - ./01_compat_tests.sh
+  - echo -e "travis_fold:end:compat_tests"
 

--- a/tests/00_unit_tests.sh
+++ b/tests/00_unit_tests.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# export PYTHONPATH=.:$PYTHONPATH
+
+set -e
+
+for file in opcodes assemble link ; do
+    echo testing $file...
+    micropython $file.py
+done

--- a/tests/01_compat_tests.sh
+++ b/tests/01_compat_tests.sh
@@ -4,35 +4,36 @@
 
 set -e
 
-for file in opcodes assemble link ; do
-    echo testing $file...
-    micropython $file.py
-done
-
 for src_file in $(ls -1 compat/*.S); do
     src_name="${src_file%.S}"
     
-    echo "Building $src_file using py-esp32-ulp"
+    echo "Testing $src_file"
+    echo -e "\tBuilding using py-esp32-ulp"
     ulp_file="${src_name}.ulp"
-    micropython -m esp32_ulp $src_file    # generates $ulp_file
+    log_file="${src_name}.log"
+    micropython -m esp32_ulp $src_file 1>$log_file   # generates $ulp_file
 
     obj_file="${src_name}.o"
     elf_file="${src_name}.elf"
     bin_file="${src_name}.bin"
 
-    echo "Building $src_file using binutils"
+    echo -e "\tBuilding using binutils"
     esp32ulp-elf-as -o $obj_file $src_file
     esp32ulp-elf-ld -T esp32.ulp.ld -o $elf_file $obj_file
     esp32ulp-elf-objcopy -O binary $elf_file $bin_file
 
-    if ! diff $ulp_file $bin_file; then
+    if ! diff $ulp_file $bin_file 1>/dev/null; then
+        echo -e "\tBuild outputs differ!"
+        echo ""
         echo "Compatibility test failed for $src_file"
+        echo "py-esp32-ulp log:"
+        cat $log_file
         echo "py-esp32-ulp output:"
-        hexdump $ulp_file
+        xxd -e $ulp_file
         echo "binutils output:"
-        hexdump $bin_file
+        xxd -e $bin_file
         exit 1
     else
-        echo "Build outputs match for $src_file"
+        echo -e "\tBuild outputs match"
     fi
 done


### PR DESCRIPTION
- place binutils and micropython builds into folds
- split test scripts into unit tests and compatibility tests
- make compatibility test output less noisy when tests pass
- use `xxd -e` instead of hexdump to display binaries in groups of 4 bytes, little-endian format.

Example of a passing test:
```
$ ./01_compat_tests.sh
Testing compat/alu.S
	Building using py-esp32-ulp
	Building using binutils
	Build outputs match
```

Example of a failing test:
```
$ ./01_compat_tests.sh
Testing compat/alu.S
	Building using py-esp32-ulp
	Building using binutils
	Build outputs differ!

Compatibility test failed for compat/alu.S
py-esp32-ulp log:
Symbols:
text section:
70400039
724ffff3
724a5a55
70600039
726ffff3
726a5a55
7207fff5
7208000c
720ffff3
72000016
7227fff5
7228000c
722ffff3
72200016
50000005
size: 60
data section:
size: 0
bss section:
size: 0
py-esp32-ulp output:
00000000: 00706c75 003c000c 00000000 70400039  ulp...<.....9.@p
00000010: 724ffff3 724a5a55 70600039 726ffff3  ..OrUZJr9.`p..or
00000020: 726a5a55 7207fff5 7208000c 720ffff3  UZjr...r...r...r
00000030: 72000016 7227fff5 7228000c 722ffff3  ...r..'r..(r../r
00000040: 72200016 50000005                    .. r...P
binutils output:
00000000: 00706c75 003c000c 00000000 70400039  ulp...<.....9.@p
00000010: 724ffff3 724a5a55 70600039 726ffff3  ..OrUZJr9.`p..or
00000020: 726a5a55 7207fff5 7208000c 720ffff3  UZjr...r...r...r
00000030: 72000016 7227fff5 7228000c 722ffff3  ...r..'r..(r../r
00000040: 72200016 50000001                    .. r...P
```