### PR TITLE
call the garbage collector now and then

### DIFF
--- a/esp32_ulp/__main__.py
+++ b/esp32_ulp/__main__.py
@@ -1,12 +1,16 @@
 import sys
 
+from .util import garbage_collect
+
 from .assemble import Assembler
 from .link import make_binary
+garbage_collect('after import')
 
 
 def src_to_binary(src):
     assembler = Assembler()
     assembler.assemble(src)
+    garbage_collect('before symbols export')
     addrs_syms = assembler.symbols.export()
     for addr, sym in addrs_syms:
         print('%04d %s' % (addr, sym))

--- a/esp32_ulp/util.py
+++ b/esp32_ulp/util.py
@@ -1,0 +1,11 @@
+DEBUG = False
+
+import gc
+
+
+def garbage_collect(msg, verbose=DEBUG):
+    free_before = gc.mem_free()
+    gc.collect()
+    free_after = gc.mem_free()
+    if verbose:
+        print("%s: %d --gc--> %d bytes free" % (msg, free_before, free_after))

--- a/tests/assemble.py
+++ b/tests/assemble.py
@@ -1,5 +1,6 @@
 from esp32_ulp.assemble import Assembler, TEXT, DATA, BSS, REL, ABS
 from esp32_ulp.assemble import SymbolTable
+from esp32_ulp.nocomment import remove_comments
 
 src = """\
 
@@ -25,7 +26,8 @@ def test_parse_line():
 
 def test_parse():
     a = Assembler()
-    result = a.parse(src)
+    lines = remove_comments(src)
+    result = a.parse(lines)
     assert None not in result
 
 


### PR DESCRIPTION
this enables the assembler to translate larger source files without running out of memory.
