### PR TITLE
update build dependencies, including all we need

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -13,7 +13,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y libffi-dev pkg-config bison flex
+        sudo apt-get install -y git build-essential libffi-dev pkg-config python3 bison flex
 
     - name: Record version
       run: |


### PR DESCRIPTION
Now the list includes all dependencies we need, even if the build image
we're building on already has some of these installed. Hopefully this
has a documentation benefit and makes future updates to later OS images
easier.