### PR TITLE
Fix relative jumps

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -13,7 +13,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y git build-essential libffi-dev pkg-config python3 bison flex
+        sudo apt-get install -y git build-essential libffi-dev pkg-config python3 bison flex xxd
 
     - name: Record version
       run: |

--- a/esp32_ulp/opcodes.py
+++ b/esp32_ulp/opcodes.py
@@ -698,9 +698,13 @@ def i_jumps(offset, threshold, condition):
         cmp_op = BRCOND_LE
     elif condition == 'ge':
         cmp_op = BRCOND_GE
-    elif condition == 'eq':  # eq == le but not lt
-        skip_cond = BRCOND_LT
-        jump_cond = BRCOND_LE
+    elif condition in ('eq', 'gt'):
+        if condition == 'eq':  # eq == le but not lt
+            skip_cond = BRCOND_LT
+            jump_cond = BRCOND_LE
+        elif condition == 'gt':  # gt == ge but not le
+            skip_cond = BRCOND_LE
+            jump_cond = BRCOND_GE
 
         # jump over next JUMPS
         skip_ins = _jump_rels(threshold, skip_cond, 2)
@@ -718,7 +722,7 @@ def no_of_instr(opcode, args):
     if opcode == 'jumpr' and get_cond(args[2]) == 'eq':
         return 2
 
-    if opcode == 'jumps' and get_cond(args[2]) == 'eq':
+    if opcode == 'jumps' and get_cond(args[2]) in ('eq', 'gt'):
         return 2
 
     return 1

--- a/esp32_ulp/opcodes.py
+++ b/esp32_ulp/opcodes.py
@@ -644,6 +644,12 @@ def i_jumpr(offset, threshold, condition):
         cmp_op = BRCOND_LT
     elif condition == 'ge':
         cmp_op = BRCOND_GE
+    elif condition == 'le':  # le == lt(threshold+1)
+        threshold += 1
+        cmp_op = BRCOND_LT
+    elif condition == 'gt':  # gt == ge(threshold+1)
+        threshold += 1
+        cmp_op = BRCOND_GE
     else:
         raise ValueError("invalid comparison condition")
     _br.imm = threshold

--- a/esp32_ulp/opcodes.py
+++ b/esp32_ulp/opcodes.py
@@ -301,7 +301,7 @@ def arg_qualify(arg):
             if 0 <= reg <= 3:
                 return ARG(REG, reg, arg)
             raise ValueError('arg_qualify: valid registers are r0, r1, r2, r3. Given: %s' % arg)
-        if arg_lower in ['--', 'eq', 'ov', 'lt', 'gt', 'ge']:
+        if arg_lower in ['--', 'eq', 'ov', 'lt', 'gt', 'ge', 'le']:
             return ARG(COND, arg_lower, arg)
     try:
         return ARG(IMM, int(arg), arg)
@@ -661,10 +661,10 @@ def i_jumps(offset, threshold, condition):
     condition = get_cond(condition)
     if condition == 'lt':
         cmp_op = BRCOND_LT
-    elif condition == 'gt':
-        cmp_op = BRCOND_GT
-    elif condition == 'eq':
-        cmp_op = BRCOND_EQ
+    elif condition == 'le':
+        cmp_op = BRCOND_LE
+    elif condition == 'ge':
+        cmp_op = BRCOND_GE
     else:
         raise ValueError("invalid comparison condition")
     _bs.imm = threshold

--- a/esp32_ulp/opcodes.py
+++ b/esp32_ulp/opcodes.py
@@ -340,7 +340,9 @@ def get_rel(arg):
     if isinstance(arg, str):
         arg = arg_qualify(arg)
     if arg.type == IMM:
-        return arg.value
+        if arg.value & 3 != 0:  # bitwise version of: arg.value % 4 != 0
+            raise ValueError('Relative offset must be a multiple of 4')
+        return arg.value >> 2  # bitwise version of: arg.value // 4
     if arg.type == SYM:
         return symbols.resolve_relative(arg.value)
     raise TypeError('wanted: immediate, got: %s' % arg.raw)

--- a/tests/compat/jumps.S
+++ b/tests/compat/jumps.S
@@ -3,6 +3,7 @@
 entry:
   nop
 
+  # jumps with labels
   jumps entry, 42, lt
   jumps entry, 42, lt
   jumps later, 42, lt
@@ -15,6 +16,18 @@ entry:
   jumps entry, 42, gt
   jumps later, 42, gt
 
+  # jumps with immediate offset (specified in bytes, but real instruction uses words)
+  jumps 0, 42, lt
+
+  jumps 4, 42, lt
+  jumps 8, 42, lt
+  jumps 32, 42, lt
+
+  jumps -4, 42, lt
+  jumps -8, 42, lt
+  jumps -32, 42, lt
+
+  # jumpr with labels
   jumpr entry, 42, lt
   jumpr later, 42, lt
   jumpr entry, 42, ge
@@ -25,6 +38,17 @@ entry:
   jumpr later, 42, gt
   jumpr entry, 42, eq
   jumpr later, 42, eq
+
+  # jumpr with immediate offset (specified in bytes, but real instruction uses words)
+  jumpr 0, 42, lt
+
+  jumpr 4, 42, lt
+  jumpr 8, 42, lt
+  jumpr 32, 42, lt
+
+  jumpr -4, 42, lt
+  jumpr -8, 42, lt
+  jumpr -32, 42, lt
 
   nop
   nop

--- a/tests/compat/jumps.S
+++ b/tests/compat/jumps.S
@@ -10,6 +10,8 @@ entry:
   jumps later, 42, le
   jumps entry, 42, ge
   jumps later, 42, ge
+  jumps entry, 42, eq
+  jumps later, 42, eq
 
   jumpr entry, 42, lt
   jumpr later, 42, lt

--- a/tests/compat/jumps.S
+++ b/tests/compat/jumps.S
@@ -12,6 +12,8 @@ entry:
   jumps later, 42, ge
   jumps entry, 42, eq
   jumps later, 42, eq
+  jumps entry, 42, gt
+  jumps later, 42, gt
 
   jumpr entry, 42, lt
   jumpr later, 42, lt

--- a/tests/compat/jumps.S
+++ b/tests/compat/jumps.S
@@ -6,6 +6,10 @@ entry:
   jumps entry, 42, lt
   jumps entry, 42, lt
   jumps later, 42, lt
+  jumps entry, 42, le
+  jumps later, 42, le
+  jumps entry, 42, ge
+  jumps later, 42, ge
 
   jumpr entry, 42, lt
   jumpr later, 42, lt

--- a/tests/compat/jumps.S
+++ b/tests/compat/jumps.S
@@ -19,6 +19,8 @@ entry:
   jumpr later, 42, le
   jumpr entry, 42, gt
   jumpr later, 42, gt
+  jumpr entry, 42, eq
+  jumpr later, 42, eq
 
   nop
   nop

--- a/tests/compat/jumps.S
+++ b/tests/compat/jumps.S
@@ -1,0 +1,18 @@
+  .text
+
+entry:
+  nop
+
+  jumps entry, 42, lt
+  jumps entry, 42, lt
+  jumps later, 42, lt
+
+  jumpr entry, 42, lt
+  jumpr later, 42, lt
+  jumpr entry, 42, ge
+  jumpr later, 42, ge
+
+  nop
+  nop
+  nop
+later:

--- a/tests/compat/jumps.S
+++ b/tests/compat/jumps.S
@@ -15,6 +15,10 @@ entry:
   jumpr later, 42, lt
   jumpr entry, 42, ge
   jumpr later, 42, ge
+  jumpr entry, 42, le
+  jumpr later, 42, le
+  jumpr entry, 42, gt
+  jumpr later, 42, gt
 
   nop
   nop

--- a/tests/compat/jumps.S
+++ b/tests/compat/jumps.S
@@ -1,4 +1,6 @@
   .text
+  .set const, 3
+  .global const  # exporting symbol is required for binutils, not important for py-esp32-ulp
 
 entry:
   nop
@@ -27,6 +29,9 @@ entry:
   jumps -8, 42, lt
   jumps -32, 42, lt
 
+  # jumps with immediate offset from absolute symbol
+  jumps const, 42, lt
+
   # jumpr with labels
   jumpr entry, 42, lt
   jumpr later, 42, lt
@@ -49,6 +54,9 @@ entry:
   jumpr -4, 42, lt
   jumpr -8, 42, lt
   jumpr -32, 42, lt
+
+  # jumps with immediate offset from absolute symbol
+  jumpr const, 42, lt
 
   nop
   nop


### PR DESCRIPTION
This PR is meant to fix #41 .

The PR is more of a prototype for now (not finished). I raised it to be able to:
1. discuss the implementation of "emit multiple instructions"
2. get ideas on a behaviour of binutils-esp32ulp that I cannot yet explain.

---
**1. opcode -> Multiple instructions**
For now the implementation (see commit fa09eb3) works by the `i_jumpr` and `i_jumpr` methods returning a `tuple` when multiple instructions should be emitted, and the assembler testing for "is this a tuple" and if so, it looping over the elements. Otherwise it does what it did before, i.e. adds 1 instruction to the section. The current structure for this logic feels a bit rough, but for now I intend mostly to get feedback on the approach.

To help this, for pass 1, when we're not yet calling the `i_*` methods, because we only want to determine section sizes and label offsets, I added a function that can return "how many instructions will this opcode result in" based on the opcode and its arguments. The default return value is 1, but for the JUMPS and JUMPR opcodes and with the specific conditions that will result in 2 instructions, the function returns 2. Simple and effective, but technically a "duplication of logic" (because `i_jumps`/`i_jumpr` methods also make this decision). Perhaps there are other approaches for how to make this even simpler or more elegant?

---
**2. Weird binutils-esp32 behaviour with negative immediate offsets**
For a reason I cannot yet figure out, when using negative immediate offsets for JUMPS or JUMPR instructions, binutils-esp32 generates instructions differently than when using label references that are before the current PC (back-jumps).

The behaviour is as follows: for SYM references, if the offset is negative, set the sign bit and use the absolute value of the offset. for IMM references however, the sign bit is set the same way, but for the offset the negative (not absolute) value is used.

At the "field" level in the opcode the difference is such that:
* For a negative symbol reference, e.g. -9, sign bit is 1 and the offset is 9
* For a negative immediate reference, e.g. -2, the sign bit is 1 and the offset is 126 (which is the 7-bit two's complement of 2)

See commit 3ae1e20 for the implementation that mirrors what binutils-esp32ulp does. So "it works", in that py-esp32-ulp will now generate the same binary output, but I still don't know **why** binutils-esp32ulp treats these offsets differently (even after a fair bit of scanning the binutils-esp32ulp source code). If we need to jump 4 words back, because there is a label 4 instructions earlier, of whether I give an immediate offset of -4, I would expect the resulting jump instruction to be the same. I have not tested this on the actual device for how the ULP interprets these different "representations".

---
**3. One more thing**
One last thing, which is not yet in this PR, is another weird behaviour of binutils-esp32ulp. This relates to using constants defined with `.set` as arguments to the JUMPS and JUMPR opcodes. I would expect them to behave like immediate offsets, but they are always "interpreted" as 0.

So the following two JUMPS statements result in the exact same instruction (namely `2a00 0084`):
```
  .set const, 42
  jumps 0, 1, lt
  jumps const, 1, lt
```

I started wondering whether this is a bug in binutils-esp32ulp? Or I have wondered if "resolving the constant" is deferred by binutils-esp32ulp to the linker perhaps, and maybe we're calling the linker wrong in the compat test scripts, but so far I cannot see that this is true. The binutils-esp32ulp test scripts call the linker the same way (then again, sadly they don't have this specific example in their tests).

---
Happy to get feedback/thought/ideas on the above, and the current implementation.

