### PR TITLE
support the ';' line separator character, aka statement separator

### DIFF
--- a/esp32_ulp/assemble.py
+++ b/esp32_ulp/assemble.py
@@ -129,9 +129,13 @@ class Assembler:
                 opcode, args = opcode_args[0], ()
         return label, opcode, args
 
+    def split_statements(self, lines):
+        for line in lines:
+            for statement in line.split(';'):
+                yield statement.rstrip()
 
     def parse(self, lines):
-        parsed = [self.parse_line(line) for line in lines]
+        parsed = [self.parse_line(line) for line in self.split_statements(lines)]
         return [p for p in parsed if p is not None]
 
 

--- a/tests/assemble.py
+++ b/tests/assemble.py
@@ -244,6 +244,21 @@ def test_symbols():
     assert st.resolve_absolute('const') == 123
 
 
+def test_support_multiple_statements_per_line():
+    src = """
+label: nop; nop;
+    wait 42
+"""
+
+    lines = Assembler().parse(src.splitlines())
+
+    assert lines == [
+        ('label', 'nop', ()),
+        (None, 'nop', ()),
+        (None, 'wait', ('42',))
+    ]
+
+
 test_parse_line()
 test_parse()
 test_assemble()
@@ -254,4 +269,5 @@ test_assemble_uppercase_opcode()
 test_assemble_evalulate_expressions()
 test_assemble_optional_comment_removal()
 test_assemble_test_regressions_from_evaluation()
+test_support_multiple_statements_per_line()
 test_symbols()

--- a/tests/compat/fixes.S
+++ b/tests/compat/fixes.S
@@ -25,4 +25,7 @@ entry:
   reg_rd 12, 7, 0
   reg_rd 0x3ff48000, 7, 0
 
+  # interpret ; as statement separator - this results in 2 NOP machine instructions
+  nop; nop;
+
   halt


### PR DESCRIPTION
I'm now trying to send more smaller PRs - this is the first one that moves us towards being able to assemble all the currently skipped examples from the binutils-esp32ulp test suite (to resolve #49).

The esp32ulp_all.s code has a `nop;` statement in it, and this commit adds support for the `;` which functions as a statement separator. (See the commit message of ce005e3 for more detail).

Side-note: Currently, due to the way labels are handled/detected, there must be a space between a `;` and the next statement, if there is another statement on the same line. The way labels are handled is another thing to be fixed (see [esp32ulp_all.s:2](https://github.com/espressif/binutils-esp32ulp/blob/249ec34cc2c9574a86f3f86bbb175a863f988bcf/gas/testsuite/gas/esp32ulp/esp32/esp32ulp_all.s#L2), where a statement follows the colon without whitespace), so a future commit may address that issue.