### PR TITLE
More fixes towards v1.0

### DIFF
--- a/esp32_ulp/assemble.py
+++ b/esp32_ulp/assemble.py
@@ -108,17 +108,21 @@ class Assembler:
         """
         if not line:
             return
-        has_label = line[0] not in '\t .'
+        has_label = ':' in line
         if has_label:
-            label_line = line.split(None, 1)
+            orig_line = line.strip()
+            label_line = orig_line.split(':', 1)
             if len(label_line) == 2:
                 label, line = label_line
             else:  # 1
                 label, line = label_line[0], None
-            label = label.rstrip(':')
+
+            if label.strip('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_$.'):  # if any chars remain
+                # if label contains other chars than allowed, it's not a label
+                label, line = None, orig_line
         else:
             label, line = None, line.lstrip()
-        if line is None:
+        if not line:
             opcode, args = None, ()
         else:
             opcode_args = line.split(None, 1)

--- a/esp32_ulp/opcodes.py
+++ b/esp32_ulp/opcodes.py
@@ -449,7 +449,7 @@ def i_tsens(reg_dest, delay):
     return _tsens.all
 
 
-def i_adc(reg_dest, adc_idx, mux):
+def i_adc(reg_dest, adc_idx, mux, _not_used=None):
     _adc.dreg = get_reg(reg_dest)
     _adc.mux = get_imm(mux)
     _adc.sar_sel = get_imm(adc_idx)

--- a/esp32_ulp/opcodes.py
+++ b/esp32_ulp/opcodes.py
@@ -619,6 +619,7 @@ def i_jump(target, condition='--'):
         raise ValueError("invalid flags condition")
     if target.type == IMM or target.type == SYM:
         _bx.dreg = 0
+        # we track label addresses in 32bit words, but immediate values are in bytes and need to get divided by 4.
         _bx.addr = get_abs(target) if target.type == SYM else get_abs(target) >> 2  # bitwise version of "// 4"
         _bx.unused = 0
         _bx.reg = 0

--- a/esp32_ulp/opcodes.py
+++ b/esp32_ulp/opcodes.py
@@ -619,7 +619,7 @@ def i_jump(target, condition='--'):
         raise ValueError("invalid flags condition")
     if target.type == IMM or target.type == SYM:
         _bx.dreg = 0
-        _bx.addr = get_abs(target)
+        _bx.addr = get_abs(target) if target.type == SYM else get_abs(target) >> 2  # bitwise version of "// 4"
         _bx.unused = 0
         _bx.reg = 0
         _bx.type = jump_type

--- a/tests/02_compat_rtc_tests.sh
+++ b/tests/02_compat_rtc_tests.sh
@@ -66,7 +66,7 @@ for src_file in ulptool/src/ulp_examples/*/*.s binutils-esp32ulp/gas/testsuite/g
     test_name="${src_name##*/}"
 
     # for now, skip files that contain known bugs in esp32_ulp (essentially a todo list of what to fix)
-    for I in esp32ulp_all esp32ulp_globals esp32ulp_jumpr esp32ulp_ranges test_reg; do
+    for I in esp32ulp_jumpr esp32ulp_ranges; do
         if [ "${test_name}" = "$I" ]; then
             # these are old bugs, and not related to the RTC macro handling functionality
             # they will still be great to fix over time

--- a/tests/assemble.py
+++ b/tests/assemble.py
@@ -60,6 +60,7 @@ def test_parse_labels_correctly():
     https://sourceware.org/binutils/docs/as/Labels.html
     """
     a = Assembler()
+    assert a.parse_line('') is None
     assert a.parse_line('label: .set const, 42') == ('label', '.set', ('const', '42',))
     assert a.parse_line('label:.set const, 42') == ('label', '.set', ('const', '42',))
     assert a.parse_line('label:') == ('label', None, ())
@@ -75,6 +76,7 @@ def test_parse_labels_correctly():
     assert a.parse_line('a_label:') == ('a_label', None, ())
     assert a.parse_line('$label:') == ('$label', None, ())
     assert a.parse_line('.label:') == ('.label', None, ())
+    assert a.parse_line('&label:') == (None, '&label:', ())  # & not a valid char in a label
 
 
 def test_parse():

--- a/tests/assemble.py
+++ b/tests/assemble.py
@@ -53,6 +53,30 @@ def test_parse_line():
     assert a.parse_line(next(lines)) == (None, '.data', ())  # test left-aligned directive is not treated as label
 
 
+def test_parse_labels_correctly():
+    """
+    description of what defines a label
+    https://sourceware.org/binutils/docs/as/Statements.html
+    https://sourceware.org/binutils/docs/as/Labels.html
+    """
+    a = Assembler()
+    assert a.parse_line('label: .set const, 42') == ('label', '.set', ('const', '42',))
+    assert a.parse_line('label:.set const, 42') == ('label', '.set', ('const', '42',))
+    assert a.parse_line('label:') == ('label', None, ())
+    assert a.parse_line('    label:') == ('label', None, ())
+    assert a.parse_line('    label:  ') == ('label', None, ())
+    assert a.parse_line('nop  ') == (None, 'nop', ())
+    assert a.parse_line('.set c, 1  ') == (None, '.set', ('c', '1',))
+    assert a.parse_line('invalid : nop') == (None, 'invalid', (': nop',))  # no whitespace between label and colon
+    assert a.parse_line('.string "hello world"') == (None, '.string', ('"hello world"',))
+    assert a.parse_line('.string "hello : world"') == (None, '.string', ('"hello : world"',))  # colon in string
+    assert a.parse_line('label::') == ('label', ':', ())
+    assert a.parse_line('label: :') == ('label', ':', ())
+    assert a.parse_line('a_label:') == ('a_label', None, ())
+    assert a.parse_line('$label:') == ('$label', None, ())
+    assert a.parse_line('.label:') == ('.label', None, ())
+
+
 def test_parse():
     a = Assembler()
     lines = remove_comments(src)
@@ -260,6 +284,7 @@ label: nop; nop;
 
 
 test_parse_line()
+test_parse_labels_correctly()
 test_parse()
 test_assemble()
 test_assemble_bss()

--- a/tests/compat/fixes.S
+++ b/tests/compat/fixes.S
@@ -28,4 +28,9 @@ entry:
   # interpret ; as statement separator - this results in 2 NOP machine instructions
   nop; nop;
 
+  # adc supports an undocumented 4th argument, which should be entirely ignored
+  # binutils-esp32ulp also ignores this argument, if present, see:
+  # https://github.com/espressif/binutils-esp32ulp/blob/249ec34cc2c9574a86f3f86bbb175a863f988bcf/gas/config/esp32ulp-parse.y#L810
+  adc r1, 0, 1, 100
+
   halt

--- a/tests/compat/jumps.S
+++ b/tests/compat/jumps.S
@@ -26,12 +26,15 @@ entry:
 
   # jumps with immediate offset (specified in bytes, but real instruction uses words)
   jumps 0, 42, lt
+  jumps 0, 42, eq  #dual-instruction condition
 
   jumps 4, 42, lt
+  jumps 4, 42, eq  #dual-instruction condition
   jumps 8, 42, lt
   jumps 32, 42, lt
 
   jumps -4, 42, lt
+  jumps -4, 42, eq  #dual-instruction condition
   jumps -8, 42, lt
   jumps -32, 42, lt
 
@@ -52,12 +55,15 @@ entry:
 
   # jumpr with immediate offset (specified in bytes, but real instruction uses words)
   jumpr 0, 42, lt
+  jumpr 0, 42, eq  #dual-instruction condition
 
   jumpr 4, 42, lt
+  jumpr 4, 42, eq  #dual-instruction condition
   jumpr 8, 42, lt
   jumpr 32, 42, lt
 
   jumpr -4, 42, lt
+  jumpr -4, 42, eq  #dual-instruction condition
   jumpr -8, 42, lt
   jumpr -32, 42, lt
 

--- a/tests/compat/jumps.S
+++ b/tests/compat/jumps.S
@@ -5,6 +5,12 @@
 entry:
   nop
 
+  # simple jumps
+  jump entry
+  jump later
+  jump 0x120, EQ
+  jump -288, EQ
+
   # jumps with labels
   jumps entry, 42, lt
   jumps entry, 42, lt

--- a/tests/compat/jumps.S
+++ b/tests/compat/jumps.S
@@ -26,15 +26,15 @@ entry:
 
   # jumps with immediate offset (specified in bytes, but real instruction uses words)
   jumps 0, 42, lt
-  jumps 0, 42, eq  #dual-instruction condition
+  jumps 0, 42, eq  # dual-instruction condition
 
   jumps 4, 42, lt
-  jumps 4, 42, eq  #dual-instruction condition
+  jumps 4, 42, eq  # dual-instruction condition
   jumps 8, 42, lt
   jumps 32, 42, lt
 
   jumps -4, 42, lt
-  jumps -4, 42, eq  #dual-instruction condition
+  jumps -4, 42, eq  # dual-instruction condition
   jumps -8, 42, lt
   jumps -32, 42, lt
 
@@ -55,15 +55,15 @@ entry:
 
   # jumpr with immediate offset (specified in bytes, but real instruction uses words)
   jumpr 0, 42, lt
-  jumpr 0, 42, eq  #dual-instruction condition
+  jumpr 0, 42, eq  # dual-instruction condition
 
   jumpr 4, 42, lt
-  jumpr 4, 42, eq  #dual-instruction condition
+  jumpr 4, 42, eq  # dual-instruction condition
   jumpr 8, 42, lt
   jumpr 32, 42, lt
 
   jumpr -4, 42, lt
-  jumpr -4, 42, eq  #dual-instruction condition
+  jumpr -4, 42, eq  # dual-instruction condition
   jumpr -8, 42, lt
   jumpr -32, 42, lt
 


### PR DESCRIPTION
Some more fixes to move us towards being able to assemble all the currently skipped examples from the binutils-esp32ulp test suite (to resolve #49).

This PR contains a few fixes - felt it was easier to send them as one PR, than 1 PR per commit.

The commits are independent of each other and can be reviewed one by one. They contain commit messages explaining what they each fix. Each commit also has a reference to the issue it fixed in the relevant binutils-esp32ulp test.

The last commits enables the tests that can now pass because of the fixes. 2 more files to go.