### PR TITLE
Improve README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ The following features are supported:
 * constants defined with ``.set``
 * constants defined with ``#define``
 * expressions in assembly code and constant definitions
-* RTC convenience macros (e.g. WRITE_RTC_REG)
+* RTC convenience macros (e.g. ``WRITE_RTC_REG``)
 * many ESP32 ULP code examples found on the web will work unmodified
 
 
@@ -52,7 +52,7 @@ To get going run the following directly on the ESP32:
    # First, upload examples/counter.py to the ESP32.
    import counter
 
-The `counter.py </examples/counter.py>`_ example shows how to assemble code, load
+The `examples/counter.py </examples/counter.py>`_ example shows how to assemble code, load
 and run the resulting binary and exchange data between the ULP and the main CPU.
 
 

--- a/README.rst
+++ b/README.rst
@@ -33,17 +33,17 @@ The following features are supported:
 Quick start
 -----------
 
-You can get going, run the following directly on the ESP32:
+To get going run the following directly on the ESP32:
 
 .. code-block:: python
 
-   # step 1: install py-esp32-ulp
-   # important: ensure the ESP32 is connected to a network with internet connectivity
+   # Step 1: Install py-esp32-ulp
+   # IMPORTANT: Ensure the ESP32 is connected to a network with internet connectivity.
    import upip
    upip.install('micropython-py-esp32-ulp')
 
-   # step 2: run an example
-   # first, upload examples/counter.py to the ESP32
+   # Step 2: Run an example
+   # First, upload examples/counter.py to the ESP32.
    import counter
 
 The `counter.py </examples/counter.py>`_ example shows how to assemble code, load

--- a/README.rst
+++ b/README.rst
@@ -86,6 +86,12 @@ Advanced usage
 
 In real world applications, you might want to separate the assembly stage from
 the loading/running stage, to avoid having to assemble the code on every startup.
+This can be useful for battery-powered applications, where every second of sleep
+time matters.
+
+Splitting the assembly and load stage can be combined with other techniques to
+for example implement a caching mechansim for the ULP binary, which automatically
+updates the binary every time the assembly source code changes.
 
 The ``esp32_ulp.assemble_file`` function stores the assembled and linked binary
 into a file with a ``.ulp`` extension, which can later be loaded directly without
@@ -98,16 +104,6 @@ assembling the source again.
 
       import esp32_ulp
       esp32_ulp.assemble_file('code.S')  # this results in code.ulp
-
-   Alternatively you can assemble the source on a PC with MicroPython, and transfer
-   the resulting ULP binary to the ESP32.
-
-   .. code-block:: python
-
-      git clone https://github.com/ThomasWaldmann/py-esp32-ulp
-      cd py-esp32-ulp
-      micropython -m esp32_ulp path/to/code.S  # this results in path/to/code.ulp
-      # now upload path/to/code.ulp to the ESP32
 
 2. The above prints out the offsets of all global symbols/labels. For the next step,
    you will need to note down the offset of the label, which represents the entry
@@ -134,6 +130,10 @@ assembling the source again.
           # e.g. for an offset of 2:
           #   2 words * 4 = 8 bytes
           ulp.run(2*4)  # specify the offset of the entry point label
+
+To update the binary every time the source code changes, you would need a mechanism
+to detect that the source code changed. Whenever needed, manually re-running the
+``assemble_file`` function as shown above, would also work.
 
 
 Preprocessor

--- a/README.rst
+++ b/README.rst
@@ -1,63 +1,177 @@
-What is py-esp32-ulp?
----------------------
+=====================
+py-esp32-ulp
+=====================
 
-It is an assembler toolchain for the ESP32 ULP (Ultra Low-Power) Co-Processor,
-written in MicroPython.
+py-esp32-ulp is an assembler toolchain for the ESP32 ULP (Ultra Low-Power)
+Co-Processor, written in MicroPython.
 
-It is able to translate small, simple assembler language programs to a
-loadable/executable machine code binary, at runtime, on the ESP32
-microcontroller, from projects implemented in MicroPython.
+It can translate small assembly language programs to a loadable/executable
+ULP machine code binary, directly on the ESP32 microcontroller.
 
-This is intended as an alternative approach to assembling such programs on a
-development machine using the binutils-esp32ulp toolchain from Espressif.
+This is intended as an alternative approach to assembling such programs using
+the binutils-esp32ulp toolchain from Espressif on a development machine.
 
 
-Status
-------
+Installation
+------------
 
-The most commonly used stuff should work. Many ULP code examples found on
-the web will work unmodified. Notably, assembler macros and #include processing
-are not supported.
+On the ESP32, install using upip:
 
-Expressions in assembly source code are supported and get evaluated during
-assembling. Only expressions evaluating to a single integer are supported.
-Constants defined with ``.set`` are supported in expressions.
+.. code-block:: python
 
-We have some unit tests and also compatibility tests that compare the output
-whether it is identical with binutils-esp32ulp output.
+   # ensure the ESP32 is connected to a network with internet connectivity
+   import upip
+   upip.install('micropython-py-esp32-ulp')
+
+On a PC, simply ``git clone`` this repo.
+
+
+Getting Started
+---------------
+
+The quickest way to get started is to try one of the `examples <examples/>`_.
+
+The simplest example is `counter.py <examples/counter.py>`_. It shows how to
+assemble code, load and run the resulting binary and exchange data between the
+ULP and the main CPU.
+
+Run the ``counter.py`` example:
+
+1. Install py-esp32-ulp onto the ESP32 as shown above
+2. Upload the `counter.py <examples/counter.py>`_ file to the ESP32
+3. Run with ``import counter``
+
+You can also try the `blink.py <examples/blink.py>`_ example, which shows how to
+let the ULP blink an LED.
+
+Look inside each example for a more detailed description.
+
+
+Support
+-------
+
+The following features are supported:
+
+* The entire `ESP32 ULP instruction set <https://esp-idf.readthedocs.io/en/latest/api-guides/ulp_instruction_set.html>`_
+* Constants defined with ``.set``
+* Constants defined with ``#define``
+* Expressions in assembly code and constant definitions
+* RTC convenience macros (e.g. WRITE_RTC_REG)
+* Many ESP32 ULP code examples found on the web will work unmodified
+
+Not currently supported:
+
+* Assembler macros using ``.macro``
+* Preprocessor macros using ``#define A(x,y) ...``
+* Including files using ``#include``
+* ESP32-S2 (not binary compatible with the ESP32)
+
+
+Requirements
+------------
+
+The minimum supported version of MicroPython is v1.12.
+
+py-esp32-ulp has been tested on the Unix port of MicroPython and on real ESP32
+devices with the chip type ESP32D0WDQ6 (revision 1) without SPIRAM.
+
+
+Advanced usage
+--------------
+
+In real world applications, you might want to separate the assembly stage from
+the loading/running stage, to avoid having to assemble the code on every startup.
+
+The ``esp32_ulp.assemble_file`` function stores the assembled and linked binary
+into a file with a ``.ulp`` extension, which can later be loaded directly without
+assembling the source again.
+
+1. Create/upload an assembly source file and run the following to get a loadable
+   ULP binary as a ``.ulp`` file:
+
+   .. code-block:: python
+
+      import esp32_ulp
+      esp32_ulp.assemble_file('code.S')  # this results in code.ulp
+
+   Alternatively you can assemble the source on a PC with MicroPython, and transfer
+   the resulting ULP binary to the ESP32.
+
+   .. code-block:: python
+
+      git clone https://github.com/ThomasWaldmann/py-esp32-ulp
+      cd py-esp32-ulp
+      micropython -m esp32_ulp path/to/code.S  # this results in path/to/code.ulp
+      # now upload path/to/code.ulp to the ESP32
+
+2. The above prints out the offsets of all global symbols/labels. For the next step,
+   you will need to note down the offset of the label, which represents the entry
+   point to your code.
+
+3. Now load and run the resulting binary as follows:
+
+   .. code-block:: python
+
+      from esp32 import ULP
+
+      ulp = ULP()
+      with open('test.ulp', 'r') as f:
+          # load the binary into RTC memory
+          ulp.load_binary(0, f.read())
+
+          # configure how often the ULP should wake up
+          ulp.set_wakeup_period(0, 500000)  # 500k usec == 0.5 sec
+
+          # start the ULP
+          # assemble_file printed offsets in number of 32-bit words.
+          # ulp.run() expects an offset in number of bytes.
+          # Thus, multiply the offset to our entry point by 4.
+          # e.g. for an offset of 2:
+          #   2 words * 4 = 8 bytes
+          ulp.run(2*4)  # specify the offset of the entry point label
+
+
+Preprocessor
+------------
 
 There is a simple preprocessor that understands just enough to allow assembling
-ULP source files containing convenience macros such as WRITE_RTC_REG. The
-preprocessor and how to use it is documented here:
-`Preprocessor support <docs/preprocess.rst>`_.
+ULP source files containing convenience macros such as WRITE_RTC_REG. This is
+especially useful for assembling ULP examples from Espressif or other ULP code
+found as part of Arduino/ESP-IDF projects.
 
-The minimum supported version of MicroPython is v1.12. py-esp32-ulp has been
-tested with MicroPython v1.12 and v1.17. It has been tested on real ESP32
-devices with the chip type ESP32D0WDQ6 (revision 1) without SPIRAM. It has
-also been tested on the Unix port.
+The preprocessor and how to use it is documented here: `Preprocessor support <docs/preprocess.rst>`_.
 
-There might be some stuff missing, some bugs and other symptoms of beta
-software. Also, error and exception handling is rather rough yet.
 
-Please be patient or contribute missing parts or fixes.
+Testing
+-------
 
-See the issue tracker for known bugs and todo items.
+There are unit tests and also compatibility tests that check whether the binary
+output is identical with what binutils-esp32ulp produces.
+
+Consult the Github Actions `workflow definition file <.github/workflows/run_tests.yaml>`_
+for how to run the different tests.
 
 
 Links
 -----
 
-We are NOT (fully) compatible with "as", but we try to be close for the stuff
-that is actually implemented:
+Espressif documentation:
 
-https://sourceware.org/binutils/docs/as/index.html
+* `ESP32 ULP coprocessor instruction set <https://esp-idf.readthedocs.io/en/latest/api-guides/ulp_instruction_set.html>`_
+* `ESP32 Technical Reference Manual <https://www.espressif.com/sites/default/files/documentation/esp32_technical_reference_manual_en.pdf>`_
 
-Espressif docs:
+GNU Assembler "as" documentation (we try to be compatible for all features that are implemented)
 
-https://esp-idf.readthedocs.io/en/latest/api-guides/ulp_instruction_set.html
+* `GNU Assembler manual <https://sourceware.org/binutils/docs/as/index.html>`_
 
-https://www.espressif.com/sites/default/files/documentation/esp32_technical_reference_manual_en.pdf
+More ULP examples:
 
-Espressif ULP examples:
+* https://github.com/espressif/esp-iot-solution/tree/master/examples/ulp_examples
+* https://github.com/duff2013/ulptool
+* https://github.com/joba-1/Blink-ULP/blob/master/main/ulp/
 
-https://github.com/espressif/esp-iot-solution/tree/master/examples/ulp_examples
+
+License
+-------
+
+This project is released under the `MIT License <LICENSE>`_.

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,11 @@
 py-esp32-ulp
 =====================
 
+.. image:: ../../actions/workflows/run_tests.yaml/badge.svg
+   :height: 20px
+   :target: ../../actions/workflows/run_tests.yaml
+   :alt: Build Status
+
 py-esp32-ulp is an assembler toolchain for the ESP32 ULP (Ultra Low-Power)
 Co-Processor, written in MicroPython.
 

--- a/README.rst
+++ b/README.rst
@@ -57,18 +57,18 @@ Support
 
 The following features are supported:
 
-* The entire `ESP32 ULP instruction set <https://esp-idf.readthedocs.io/en/latest/api-guides/ulp_instruction_set.html>`_
-* Constants defined with ``.set``
-* Constants defined with ``#define``
-* Expressions in assembly code and constant definitions
+* the entire `ESP32 ULP instruction set <https://esp-idf.readthedocs.io/en/latest/api-guides/ulp_instruction_set.html>`_
+* constants defined with ``.set``
+* constants defined with ``#define``
+* expressions in assembly code and constant definitions
 * RTC convenience macros (e.g. WRITE_RTC_REG)
-* Many ESP32 ULP code examples found on the web will work unmodified
+* many ESP32 ULP code examples found on the web will work unmodified
 
-Not currently supported:
+Currently not supported:
 
-* Assembler macros using ``.macro``
-* Preprocessor macros using ``#define A(x,y) ...``
-* Including files using ``#include``
+* assembler macros using ``.macro``
+* preprocessor macros using ``#define A(x,y) ...``
+* including files using ``#include``
 * ESP32-S2 (not binary compatible with the ESP32)
 
 

--- a/README.rst
+++ b/README.rst
@@ -17,43 +17,8 @@ This is intended as an alternative approach to assembling such programs using
 the binutils-esp32ulp toolchain from Espressif on a development machine.
 
 
-Installation
-------------
-
-On the ESP32, install using upip:
-
-.. code-block:: python
-
-   # ensure the ESP32 is connected to a network with internet connectivity
-   import upip
-   upip.install('micropython-py-esp32-ulp')
-
-On a PC, simply ``git clone`` this repo.
-
-
-Getting Started
----------------
-
-The quickest way to get started is to try one of the `examples <examples/>`_.
-
-The simplest example is `counter.py <examples/counter.py>`_. It shows how to
-assemble code, load and run the resulting binary and exchange data between the
-ULP and the main CPU.
-
-Run the ``counter.py`` example:
-
-1. Install py-esp32-ulp onto the ESP32 as shown above
-2. Upload the `counter.py <examples/counter.py>`_ file to the ESP32
-3. Run with ``import counter``
-
-You can also try the `blink.py <examples/blink.py>`_ example, which shows how to
-let the ULP blink an LED.
-
-Look inside each example for a more detailed description.
-
-
-Support
--------
+Features
+--------
 
 The following features are supported:
 
@@ -64,12 +29,33 @@ The following features are supported:
 * RTC convenience macros (e.g. WRITE_RTC_REG)
 * many ESP32 ULP code examples found on the web will work unmodified
 
-Currently not supported:
 
-* assembler macros using ``.macro``
-* preprocessor macros using ``#define A(x,y) ...``
-* including files using ``#include``
-* ESP32-S2 (not binary compatible with the ESP32)
+Quick start
+-----------
+
+You can get going, run the following directly on the ESP32:
+
+.. code-block:: python
+
+   # step 1: install py-esp32-ulp
+   # important: ensure the ESP32 is connected to a network with internet connectivity
+   import upip
+   upip.install('micropython-py-esp32-ulp')
+
+   # step 2: run an example
+   # first, upload examples/counter.py to the ESP32
+   import counter
+
+The `counter.py </examples/counter.py>`_ example shows how to assemble code, load
+and run the resulting binary and exchange data between the ULP and the main CPU.
+
+You can also try the `blink.py </examples/blink.py>`_ example, which shows how to
+let the ULP blink an LED.
+
+
+Documentation
+-------------
+See `docs/index.rst </docs/index.rst>`_.
 
 
 Requirements
@@ -77,106 +63,11 @@ Requirements
 
 The minimum supported version of MicroPython is v1.12.
 
-py-esp32-ulp has been tested on the Unix port of MicroPython and on real ESP32
-devices with the chip type ESP32D0WDQ6 (revision 1) without SPIRAM.
-
-
-Advanced usage
---------------
-
-In real world applications, you might want to separate the assembly stage from
-the loading/running stage, to avoid having to assemble the code on every startup.
-This can be useful for battery-powered applications, where every second of sleep
-time matters.
-
-Splitting the assembly and load stage can be combined with other techniques to
-for example implement a caching mechansim for the ULP binary, which automatically
-updates the binary every time the assembly source code changes.
-
-The ``esp32_ulp.assemble_file`` function stores the assembled and linked binary
-into a file with a ``.ulp`` extension, which can later be loaded directly without
-assembling the source again.
-
-1. Create/upload an assembly source file and run the following to get a loadable
-   ULP binary as a ``.ulp`` file:
-
-   .. code-block:: python
-
-      import esp32_ulp
-      esp32_ulp.assemble_file('code.S')  # this results in code.ulp
-
-2. The above prints out the offsets of all global symbols/labels. For the next step,
-   you will need to note down the offset of the label, which represents the entry
-   point to your code.
-
-3. Now load and run the resulting binary as follows:
-
-   .. code-block:: python
-
-      from esp32 import ULP
-
-      ulp = ULP()
-      with open('test.ulp', 'r') as f:
-          # load the binary into RTC memory
-          ulp.load_binary(0, f.read())
-
-          # configure how often the ULP should wake up
-          ulp.set_wakeup_period(0, 500000)  # 500k usec == 0.5 sec
-
-          # start the ULP
-          # assemble_file printed offsets in number of 32-bit words.
-          # ulp.run() expects an offset in number of bytes.
-          # Thus, multiply the offset to our entry point by 4.
-          # e.g. for an offset of 2:
-          #   2 words * 4 = 8 bytes
-          ulp.run(2*4)  # specify the offset of the entry point label
-
-To update the binary every time the source code changes, you would need a mechanism
-to detect that the source code changed. Whenever needed, manually re-running the
-``assemble_file`` function as shown above, would also work.
-
-
-Preprocessor
-------------
-
-There is a simple preprocessor that understands just enough to allow assembling
-ULP source files containing convenience macros such as WRITE_RTC_REG. This is
-especially useful for assembling ULP examples from Espressif or other ULP code
-found as part of Arduino/ESP-IDF projects.
-
-The preprocessor and how to use it is documented here: `Preprocessor support <docs/preprocess.rst>`_.
-
-
-Testing
--------
-
-There are unit tests and also compatibility tests that check whether the binary
-output is identical with what binutils-esp32ulp produces.
-
-Consult the Github Actions `workflow definition file <.github/workflows/run_tests.yaml>`_
-for how to run the different tests.
-
-
-Links
------
-
-Espressif documentation:
-
-* `ESP32 ULP coprocessor instruction set <https://esp-idf.readthedocs.io/en/latest/api-guides/ulp_instruction_set.html>`_
-* `ESP32 Technical Reference Manual <https://www.espressif.com/sites/default/files/documentation/esp32_technical_reference_manual_en.pdf>`_
-
-GNU Assembler "as" documentation (we try to be compatible for all features that are implemented)
-
-* `GNU Assembler manual <https://sourceware.org/binutils/docs/as/index.html>`_
-
-More ULP examples:
-
-* https://github.com/espressif/esp-iot-solution/tree/master/examples/ulp_examples
-* https://github.com/duff2013/ulptool
-* https://github.com/joba-1/Blink-ULP/blob/master/main/ulp/
+An ESP32 is required to run the ULP machine code binary produced by py-esp32-ulp
+(the ESP32-S2 will not work as it is not binary compatible with the ESP32).
 
 
 License
 -------
 
-This project is released under the `MIT License <LICENSE>`_.
+This project is released under the `MIT License </LICENSE>`_.

--- a/README.rst
+++ b/README.rst
@@ -1,11 +1,15 @@
-=====================
-py-esp32-ulp
-=====================
+.. start-badges
 
 .. image:: ../../actions/workflows/run_tests.yaml/badge.svg
    :height: 20px
    :target: ../../actions/workflows/run_tests.yaml
    :alt: Build Status
+
+.. end-badges
+
+=====================
+py-esp32-ulp
+=====================
 
 py-esp32-ulp is an assembler toolchain for the ESP32 ULP (Ultra Low-Power)
 Co-Processor, written in MicroPython.
@@ -15,6 +19,8 @@ ULP machine code binary, directly on the ESP32 microcontroller.
 
 This is intended as an alternative approach to assembling such programs using
 the binutils-esp32ulp toolchain from Espressif on a development machine.
+
+It can also be useful in cases where binutils-esp32ulp is not available.
 
 
 Features
@@ -48,9 +54,6 @@ To get going run the following directly on the ESP32:
 
 The `counter.py </examples/counter.py>`_ example shows how to assemble code, load
 and run the resulting binary and exchange data between the ULP and the main CPU.
-
-You can also try the `blink.py </examples/blink.py>`_ example, which shows how to
-let the ULP blink an LED.
 
 
 Documentation

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,189 @@
+py-esp32-ulp Documentation
+==========================
+
+py-esp32-ulp is an assembler toolchain for the ESP32 ULP (Ultra Low-Power)
+Co-Processor, written in MicroPython.
+
+
+What is it useful for?
+----------------------
+
+It can translate small assembly language programs to a loadable/executable
+ULP machine code binary, directly on the ESP32 microcontroller.
+
+This is intended as an alternative approach to assembling such programs using
+the binutils-esp32ulp toolchain from Espressif on a development machine.
+
+It can also be useful in cases where binutils-esp32ulp is not available.
+
+
+Features
+--------
+
+The following features are supported:
+
+* the entire `ESP32 ULP instruction set <https://esp-idf.readthedocs.io/en/latest/api-guides/ulp_instruction_set.html>`_
+* constants defined with ``.set``
+* constants defined with ``#define``
+* expressions in assembly code and constant definitions
+* RTC convenience macros (e.g. WRITE_RTC_REG)
+* many ESP32 ULP code examples found on the web will work unmodified
+
+
+Limitations
+-----------
+
+Currently the following are not supported:
+
+* assembler macros using ``.macro``
+* preprocessor macros using ``#define A(x,y) ...``
+* including files using ``#include``
+* ESP32-S2 (not binary compatible with the ESP32)
+
+
+Installation
+------------
+
+On the ESP32, install using upip:
+
+.. code-block:: python
+
+   # ensure the ESP32 is connected to a network with internet connectivity
+   import upip
+   upip.install('micropython-py-esp32-ulp')
+
+On a PC, simply ``git clone`` this repo.
+
+
+Examples
+--------
+
+Quick start
++++++++++++
+The quickest way to get started is to try one of the `examples </examples/>`_.
+
+The simplest example is `counter.py </examples/counter.py>`_. It shows how to
+assemble code, load and run the resulting binary and exchange data between the
+ULP and the main CPU.
+
+Run the ``counter.py`` example:
+
+1. Install py-esp32-ulp onto the ESP32 as shown above
+2. Upload the `counter.py </examples/counter.py>`_ file to the ESP32
+3. Run with ``import counter``
+
+You can also try the `blink.py </examples/blink.py>`_ example, which shows how to
+let the ULP blink an LED.
+
+Look inside each example for a more detailed description.
+
+Using on a PC
++++++++++++++
+On a PC with the unix port of MicroPython, you can assemble source code as
+follows:
+
+.. code-block:: shell
+
+   git clone https://github.com/ThomasWaldmann/py-esp32-ulp.git
+   cd py-esp32-ulp
+   micropython -m esp32_ulp path/to/code.S  # this results in path/to/code.ulp
+
+More examples
++++++++++++++
+More ULP examples from around the web:
+
+* https://github.com/espressif/esp-iot-solution/tree/master/examples/ulp_examples
+* https://github.com/duff2013/ulptool
+* https://github.com/joba-1/Blink-ULP/blob/master/main/ulp/
+
+
+Advanced usage
+--------------
+
+In real world applications, you might want to separate the assembly stage from
+the loading/running stage, to avoid having to assemble the code on every startup.
+This can be useful for battery-powered applications, where every second of sleep
+time matters.
+
+Splitting the assembly and load stage can be combined with other techniques to
+for example implement a caching mechansim for the ULP binary, which automatically
+updates the binary every time the assembly source code changes.
+
+The ``esp32_ulp.assemble_file`` function stores the assembled and linked binary
+into a file with a ``.ulp`` extension, which can later be loaded directly without
+assembling the source again.
+
+1. Create/upload an assembly source file and run the following to get a loadable
+   ULP binary as a ``.ulp`` file:
+
+   .. code-block:: python
+
+      import esp32_ulp
+      esp32_ulp.assemble_file('code.S')  # this results in code.ulp
+
+2. The above prints out the offsets of all global symbols/labels. For the next step,
+   you will need to note down the offset of the label, which represents the entry
+   point to your code.
+
+3. Now load and run the resulting binary as follows:
+
+   .. code-block:: python
+
+      from esp32 import ULP
+
+      ulp = ULP()
+      with open('test.ulp', 'r') as f:
+          # load the binary into RTC memory
+          ulp.load_binary(0, f.read())
+
+          # configure how often the ULP should wake up
+          ulp.set_wakeup_period(0, 500000)  # 500k usec == 0.5 sec
+
+          # start the ULP
+          # assemble_file printed offsets in number of 32-bit words.
+          # ulp.run() expects an offset in number of bytes.
+          # Thus, multiply the offset to our entry point by 4.
+          # e.g. for an offset of 2:
+          #   2 words * 4 = 8 bytes
+          ulp.run(2*4)  # specify the offset of the entry point label
+
+To update the binary every time the source code changes, you would need a mechanism
+to detect that the source code changed. Whenever needed, manually re-running the
+``assemble_file`` function as shown above, would also work.
+
+
+Preprocessor
+------------
+
+There is a simple preprocessor that understands just enough to allow assembling
+ULP source files containing convenience macros such as WRITE_RTC_REG. This is
+especially useful for assembling ULP examples from Espressif or other ULP code
+found as part of Arduino/ESP-IDF projects.
+
+The preprocessor and how to use it is documented here: `Preprocessor support </docs/preprocess.rst>`_.
+
+
+Testing
+-------
+
+There are unit tests and also compatibility tests that check whether the binary
+output is identical with what binutils-esp32ulp produces.
+
+py-esp32-ulp has been tested on the Unix port of MicroPython and on real ESP32
+devices with the chip type ESP32D0WDQ6 (revision 1) without SPIRAM.
+
+Consult the Github Actions `workflow definition file </.github/workflows/run_tests.yaml>`_
+for how to run the different tests.
+
+
+Links
+-----
+
+Espressif documentation:
+
+* `ESP32 ULP coprocessor instruction set <https://esp-idf.readthedocs.io/en/latest/api-guides/ulp_instruction_set.html>`_
+* `ESP32 Technical Reference Manual <https://www.espressif.com/sites/default/files/documentation/esp32_technical_reference_manual_en.pdf>`_
+
+GNU Assembler "as" documentation (we try to be compatible for all features that are implemented)
+
+* `GNU Assembler manual <https://sourceware.org/binutils/docs/as/index.html>`_

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,12 +4,15 @@ py-esp32-ulp Documentation
 py-esp32-ulp is an assembler toolchain for the ESP32 ULP (Ultra Low-Power)
 Co-Processor, written in MicroPython.
 
+.. contents:: Table of Contents
+
 
 What is it useful for?
 ----------------------
 
-It can translate small assembly language programs to a loadable/executable
-ULP machine code binary, directly on the ESP32 microcontroller.
+py-esp32-ulp can translate small assembly language programs to a
+loadable/executable ULP machine code binary, directly on the ESP32
+microcontroller.
 
 This is intended as an alternative approach to assembling such programs using
 the binutils-esp32ulp toolchain from Espressif on a development machine.
@@ -55,21 +58,20 @@ On the ESP32, install using upip:
 On a PC, simply ``git clone`` this repo.
 
 
-Examples
---------
+Getting started
+---------------
 
-Quick start
-+++++++++++
-The quickest way to get started is to try one of the `examples </examples/>`_.
+On the ESP32
+++++++++++++
 
-The simplest example is `counter.py </examples/counter.py>`_. It shows how to
-assemble code, load and run the resulting binary and exchange data between the
-ULP and the main CPU.
+The simplest example to try on the ESP32 is `counter.py </examples/counter.py>`_.
+It shows how to assemble code, load and run the resulting binary and exchange
+data between the ULP and the main CPU.
 
 Run the ``counter.py`` example:
 
 1. Install py-esp32-ulp onto the ESP32 as shown above
-2. Upload the `counter.py </examples/counter.py>`_ file to the ESP32
+2. Upload the `examples/counter.py </examples/counter.py>`_ file to the ESP32
 3. Run with ``import counter``
 
 You can also try the `blink.py </examples/blink.py>`_ example, which shows how to
@@ -77,8 +79,10 @@ let the ULP blink an LED.
 
 Look inside each example for a more detailed description.
 
-Using on a PC
-+++++++++++++
+
+On a PC
++++++++
+
 On a PC with the unix port of MicroPython, you can assemble source code as
 follows:
 
@@ -88,9 +92,11 @@ follows:
    cd py-esp32-ulp
    micropython -m esp32_ulp path/to/code.S  # this results in path/to/code.ulp
 
+
 More examples
 +++++++++++++
-More ULP examples from around the web:
+
+Other ULP examples from around the web:
 
 * https://github.com/espressif/esp-iot-solution/tree/master/examples/ulp_examples
 * https://github.com/duff2013/ulptool
@@ -100,30 +106,30 @@ More ULP examples from around the web:
 Advanced usage
 --------------
 
-In real world applications, you might want to separate the assembly stage from
-the loading/running stage, to avoid having to assemble the code on every startup.
-This can be useful for battery-powered applications, where every second of sleep
+In some applications you might want to separate the assembly stage from the
+loading/running stage, to avoid having to assemble the code on every startup.
+This can be useful in battery-powered applications where every second of sleep
 time matters.
 
-Splitting the assembly and load stage can be combined with other techniques to
-for example implement a caching mechansim for the ULP binary, which automatically
-updates the binary every time the assembly source code changes.
+Splitting the assembly and load stage can be combined with other techniques,
+for example to implement a caching mechansim for the ULP binary that
+automatically updates the binary every time the assembly source code changes.
 
-The ``esp32_ulp.assemble_file`` function stores the assembled and linked binary
-into a file with a ``.ulp`` extension, which can later be loaded directly without
-assembling the source again.
+The ``esp32_ulp.assemble_file`` function can be used to assemble and link an
+assembly source file into a machine code binary file with a ``.ulp`` extension.
+That file can then be loaded directly without assembling the source again.
 
-1. Create/upload an assembly source file and run the following to get a loadable
-   ULP binary as a ``.ulp`` file:
+1. Create/upload an assembly source file and run the following to get a
+   loadable ULP binary as a ``.ulp`` file:
 
    .. code-block:: python
 
       import esp32_ulp
       esp32_ulp.assemble_file('code.S')  # this results in code.ulp
 
-2. The above prints out the offsets of all global symbols/labels. For the next step,
-   you will need to note down the offset of the label, which represents the entry
-   point to your code.
+2. The above prints out the offsets of all global symbols/labels. For the next
+   step, you will need to note down the offset of the label, which represents
+   the entry point to your code.
 
 3. Now load and run the resulting binary as follows:
 
@@ -147,9 +153,10 @@ assembling the source again.
           #   2 words * 4 = 8 bytes
           ulp.run(2*4)  # specify the offset of the entry point label
 
-To update the binary every time the source code changes, you would need a mechanism
-to detect that the source code changed. Whenever needed, manually re-running the
-``assemble_file`` function as shown above, would also work.
+To update the binary every time the source code changes, you would need a
+mechanism to detect that the source code changed. This could trigger a re-run
+of the ``assemble_file`` function to update the binary. Manually re-running
+this function as needed would also work.
 
 
 Preprocessor

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,47 +1,13 @@
 py-esp32-ulp Documentation
 ==========================
 
-py-esp32-ulp is an assembler toolchain for the ESP32 ULP (Ultra Low-Power)
-Co-Processor, written in MicroPython.
-
 .. contents:: Table of Contents
 
 
-What is it useful for?
-----------------------
-
-py-esp32-ulp can translate small assembly language programs to a
-loadable/executable ULP machine code binary, directly on the ESP32
-microcontroller.
-
-This is intended as an alternative approach to assembling such programs using
-the binutils-esp32ulp toolchain from Espressif on a development machine.
-
-It can also be useful in cases where binutils-esp32ulp is not available.
-
-
-Features
+Overview
 --------
 
-The following features are supported:
-
-* the entire `ESP32 ULP instruction set <https://esp-idf.readthedocs.io/en/latest/api-guides/ulp_instruction_set.html>`_
-* constants defined with ``.set``
-* constants defined with ``#define``
-* expressions in assembly code and constant definitions
-* RTC convenience macros (e.g. WRITE_RTC_REG)
-* many ESP32 ULP code examples found on the web will work unmodified
-
-
-Limitations
------------
-
-Currently the following are not supported:
-
-* assembler macros using ``.macro``
-* preprocessor macros using ``#define A(x,y) ...``
-* including files using ``#include``
-* ESP32-S2 (not binary compatible with the ESP32)
+`README.rst </README.rst>`_ gives a general overview of this project.
 
 
 Installation
@@ -168,6 +134,17 @@ especially useful for assembling ULP examples from Espressif or other ULP code
 found as part of Arduino/ESP-IDF projects.
 
 The preprocessor and how to use it is documented here: `Preprocessor support </docs/preprocess.rst>`_.
+
+
+Limitations
+-----------
+
+Currently the following are not supported:
+
+* assembler macros using ``.macro``
+* preprocessor macros using ``#define A(x,y) ...``
+* including files using ``#include``
+* ESP32-S2 (not binary compatible with the ESP32)
 
 
 Testing

--- a/docs/preprocess.rst
+++ b/docs/preprocess.rst
@@ -1,5 +1,6 @@
+=====================
 Preprocessor
----------------------
+=====================
 
 py-esp32-ulp contains a small preprocessor, which aims to fulfill one goal:
 facilitate assembling of ULP code from Espressif and other open-source

--- a/examples/README
+++ b/examples/README
@@ -1,3 +1,0 @@
-To run the micropython examples which load and run binaries on the ULP,
-you need a ESP32 MicroPython build that was made after 2018-05-01.
-

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,28 @@
-from pathlib import Path
-from setuptools import setup
+import re
 import sdist_upip
-
-
-HERE = Path(__file__).parent
-README = (HERE / 'README.rst').read_text()
+from setuptools import setup
 
 VERSION = "1.0.0"
+
+
+def long_desc_from_readme():
+    with open('README.rst', 'r') as fd:
+        long_description = fd.read()
+
+        # remove badges
+        long_description = re.compile(r'^\.\. start-badges.*^\.\. end-badges', re.M | re.S).sub('', long_description)
+
+        # strip links. keep link name and use literal text formatting
+        long_description = re.sub(r'`([^<`]+) </[^>]+>`_', '``\\1``', long_description)
+
+        return long_description
+
 
 setup(
     name="micropython-py-esp32-ulp",
     version=VERSION,
     description="Assembler toolchain for the ESP32 ULP co-processor, written in MicroPython",
-    long_description=README,
+    long_description=long_desc_from_readme(),
     long_description_content_type='text/x-rst',
     url="https://github.com/ThomasWaldmann/py-esp32-ulp",
     license="MIT",


### PR DESCRIPTION
This PR aims to improve the README, as suggested in #49, to make it easier to read and understand how to get started with py-esp32-ulp.

The main change to the README might be easier to look at by looking at the [file](https://github.com/ThomasWaldmann/py-esp32-ulp/blob/eba2ddb/README.rst) rather than the [patch](https://github.com/ThomasWaldmann/py-esp32-ulp/commit/eba2ddb).

* I have added "installation" and "getting started" sections and rearranged content to try get the user going as quickly as possible. Information such as what is supported and what minimum MicroPython version is required is further down.
* In general, I have also tried to shorten existing text to make it more concise where possible.
* There is now also a build-status badge just below the heading.

The README has gotten much longer, and I did start wondering, whether it to shorten it and to move the rest into "Documentation". But, given that the most important content is at the top, I decided to keep it as is for now.

**NOTE:** For now we should **not** merge this, as I noticed the relative links used in the README don't work on PyPI (see https://test.pypi.org/project/micropython-py-esp32-ulp/). I will still try to find a solution, but for now I thought I could already get feedback on the README content/structure/friendliness/etc.