### PR TITLE
Only package the main source for PyPI

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,11 @@
 # stuff we need to include into the sdist is handled automatically by
 # setuptools_scm - it includes all git-committed files.
-# but we want to exclude some committed files/dirs not needed in the sdist:
-exclude .gitattributes .gitignore
+# but we want only the main source code and exclude everything else
+# to not waste space on the esp32
+# (upip packages are not installable by pip on a PC, so on a PC one
+# would git clone anyway and get all the other files)
+exclude *  # exclude all files in repo root
 prune .github
+prune docs
+prune examples
+prune tests


### PR DESCRIPTION
This PR changes MANIFEST.in to exclude everything other than the main source of py-esp32-ulp, such as documentation and tests.

The approach used here is to exclude all files from the root (since the main source lives in esp32_ulp/) and also exclude all other directories by name. (i.e. include all, and then remove most things)

Semantically, I would have wanted to express the opposite: "exclude all, and only include esp32_ulp/". However, this also ended up excluding metadata files that setuptools put in the archive. I could include them again explicitly, but I think this could cause unexpected (hard-to-debug) behaviour in the future, if for example a future version of setuptools added more metadata files, or changed the name of this metadata file. It feels like something that could easily go by unnoticed.

In contrast, if a future change in py-esp32-ulp added a new directory of file, it would be quite noticeable (and understandable) if those files ended up in the package, because MAINFEST.in was not updated to specifically exclude them.

This is why I chose the approach I did.

#### Footnote
With the opposite approach, MANIFEST.in would have looked like this:
```
exclude *
prune *
include esp32_ulp/*.py
include micropython_py_esp32_ulp.egg-info/PKG-INFO
```
(notice having the specifically also include the PKG-INFO file)

Maybe there are other / cleaner ways of achieving the "only package esp32_ulp/*.py" intention?